### PR TITLE
Fix Issue of Animation Not Triggering When Returning to Homepage with pjax

### DIFF
--- a/dist/lib/pjax-handler.js
+++ b/dist/lib/pjax-handler.js
@@ -390,10 +390,11 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // Example of registering custom page handlers
-PageRegistry.registerPage('/', {
+PageRegistry.registerPage('/index.html', {
     onLoad: ({container}) => {
         console.log('Home page loaded');
         // Any special initialization for home page
+        document.dispatchEvent(new Event('scroll'));
     }
 });
 


### PR DESCRIPTION
When using pjax, the page does not reload script.js when returning to the homepage from coc. Additionally, if scrollY is 0 at that time, the event is not triggered, causing the page animation not to start.


https://github.com/user-attachments/assets/31b05d6b-aaf2-4cee-9c86-285d0f239504